### PR TITLE
fix: update price from gnfd is not accurate

### DIFF
--- a/monitor/gnfd_block_processor.go
+++ b/monitor/gnfd_block_processor.go
@@ -253,8 +253,8 @@ func (p *GnfdBlockProcessor) handleEventUpdateGroupExtra(blockHeight uint64, eve
 		return rawSql, err
 	}
 
-	return fmt.Sprintf("update items set description = '%s', url = '%s', price = %s, updated_gnfd_height = %d where group_id = %d",
-		escape(extra.Desc), escape(extra.Url), extra.Price, blockHeight, updateGroupExtra.GroupId.Uint64()), nil
+	return fmt.Sprintf("update items set description = '%s', url = '%s',updated_gnfd_height = %d where group_id = %d",
+		escape(extra.Desc), escape(extra.Url), blockHeight, updateGroupExtra.GroupId.Uint64()), nil
 }
 
 func (p *GnfdBlockProcessor) handleEventPutPolicy(blockHeight uint64, event abciTypes.Event) (string, error) {


### PR DESCRIPTION
### Description

After the item is listed, if the `Extra` is updated on GNFD side not from BSC. Then the price is incorrect.

### Rationale

Bug fix

### Example

NA

### Changes

Notable changes:
* NA